### PR TITLE
esio_socket_bulk: handle encoding empty chunks

### DIFF
--- a/src/esio_socket_bulk.erl
+++ b/src/esio_socket_bulk.erl
@@ -157,8 +157,11 @@ identity_bulk(Uri) ->
 encode(_Uri, {}) ->
    [];
 encode(Uri, Chunk) ->
-   {_, Key, Val} = deq:head(Chunk),
-   [encode(Uri, Key, Val) | encode(Uri, deq:tail(Chunk))].
+   case deq:head(Chunk) of
+      undefined -> [];
+      {_, Key, Val} -> 
+         [encode(Uri, Key, Val) | encode(Uri, deq:tail(Chunk))]
+   end.
 
 encode(Uri, {urn, Type, Key}, Val) ->
    Cask = hd(uri:segments(Uri)),


### PR DESCRIPTION
Fixes crash on empty chunk

```
(<0.1407.0>) call esio_socket_bulk:encode({uri,http,
     {uval,undefined,<<"example.com">>,9200,<<"/mqtt/_bulk">>,undefined,
           undefined}},{queue,0,[],[]})
12:58:55.561 [error] gen_server <0.1407.0> terminated with reason: no match of right hand value undefined in esio_socket_bulk:encode/2 line 160
```