### PR TITLE
esio_socket_bulk: handle close

### DIFF
--- a/src/esio_socket_bulk.erl
+++ b/src/esio_socket_bulk.erl
@@ -86,7 +86,19 @@ handle(sync, _, #{uri := Uri, opts := Opts, chunk := Chunk0, t := T} = State0) -
                ]
             )
          }
-   end.
+   end;
+
+handle(close, _Pipe, #{uri := Uri, opts := Opts, chunk := Chunk0, t := T} = State0) ->
+   %% We should not discard existing messages so let's send them immediately, and then stop.
+   tempus:cancel(T),
+   http_return(State0,
+               [either ||
+                  identity_bulk(Uri),
+                  http_bulk(_, Chunk0, Opts),
+                  http_run(_, State0)
+               ]
+            ),
+   {stop, normal, State}.
 
 
 %%%----------------------------------------------------------------------------   

--- a/src/esio_socket_bulk.erl
+++ b/src/esio_socket_bulk.erl
@@ -98,7 +98,7 @@ handle(close, _Pipe, #{uri := Uri, opts := Opts, chunk := Chunk0, t := T} = Stat
                   http_run(_, State0)
                ]
             ),
-   {stop, normal, State}.
+   {stop, normal, State0}.
 
 
 %%%----------------------------------------------------------------------------   


### PR DESCRIPTION
Fixes crashes similar to the following:

```
[error] Supervisor esio_socket_bulk_sup had child esio_socket_bulk started with {esio_socket_bulk,start_link,undefined} at <0.1432.0> exit with reason no function clause matching esio_socket_bulk:handle(close, {pipe,<0.1431.0>,undefined}, #{chunk => {queue,0,[],[]},n => 500,opts => [bulk],t => {timer,60000,#Ref<0.0.7.1616>},uri => {...},...}) line 53 in context child_terminated
```